### PR TITLE
Add carousel with recent talks

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
       integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
       crossorigin="anonymous"
     />
+    <link 
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.0/font/bootstrap-icons.css" 
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link
       rel="stylesheet"
@@ -19,7 +23,7 @@
       href="https://fonts.googleapis.com/css2?family=Roboto+Condensed&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles.css"
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <div>
@@ -102,6 +106,76 @@
               in the field. Sign up now for our next event and be a part of this
               exciting community of software engineers in Berlin.
             </p>
+            <br />
+            <div id="talksCarousel" class="carousel slide" data-bs-ride="carousel">
+              <div class="carousel-heading">
+                <h3>Recent talks</h3>
+              </div>
+              <div class="carousel-inner">
+                <div class="carousel-item active">
+                    <div class="carousel-content">
+                      <div class="card-heading">
+                        <h5>Vladimir: Entity-Component-System architecture</h5>
+                      </div>
+                      <div class="card-content">
+                        <p class="my-0 text-left">An overview of ECS and how it changed the way you could develop game systems.</p>
+                        <p class="learn-more my-0 text-left">Learn more: <a class="external-link" href="https://unity.com/ecs">external link</a></p>
+                      </div>
+                    </div>
+                </div>
+                <div class="carousel-item">
+                    <div class="carousel-content">
+                      <div class="card-heading">
+                        <h5>Johannes: A social platform to ensure trust and authenticity in a world of GenAI</h5>
+                      </div>
+                      <div class="card-content">
+                        <p class="my-0 text-left">An inspiring talk on the possibility of an online social platform with built-in credibility verification methods.</p>
+                      </div>
+                      </div>
+                </div>
+                <div class="carousel-item">
+                    <div class="carousel-content">
+                      <div class="card-heading">
+                        <h5>Jonas: introduction to Kubernetes</h5>
+                      </div>
+                      <div class="card-content">
+                        <p class="my-0 text-left">A lightning talk on how Kubernetes can change a developer's day-to-day work.</p>
+                        <p class="learn-more my-0 text-left">Learn more: <a class="external-link" href="https://www.edx.org/learn/kubernetes/the-linux-foundation-introduction-to-kubernetes">external link</a></p>
+                      </div>
+                    </div>
+                </div>
+                <div class="carousel-item">
+                  <div class="carousel-content">
+                    <div class="card-heading">
+                      <h5>Evgenii: Transactional Outbox pattern</h5>
+                    </div>
+                    <div class="card-content">
+                      <p class="my-0 text-left">An overview of the design pattern for streamlining dual-write operations.</p>
+                      <p class="learn-more my-0 text-left">Learn more: <a class="external-link" href="https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/transactional-outbox.html">external link</a></p>
+                    </div>
+                  </div>
+                </div>
+                <div class="carousel-item">
+                  <div class="carousel-content">
+                    <div class="card-heading">
+                      <h5>Vladimir: Using Ollama to conveniently run LLMs locally</h5>
+                    </div>
+                    <div class="card-content">
+                      <p class="my-0 text-left">An introduction to the open-source model library client Ollama.</p>
+                      <p class="learn-more my-0 text-left">Learn more: <a class="external-link" href="https://ollama.ai/">external link</a></p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <button class="carousel-control-prev" type="button" data-bs-target="#talksCarousel" data-bs-slide="prev">
+                <span class="bi-chevron-left" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#talksCarousel" data-bs-slide="next">
+                <span class="bi-chevron-right" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+              </button>
+            </div>               
             <br />
             <h2>Dates:</h2>
             <a

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,6 @@
 }
 
 .navbar-brand{
-
     font-size: 30px;
     font-family: 'Roboto Condensed', sans-serif;
     font-weight: bold;
@@ -28,4 +27,30 @@
 .footer{
     font-size: 10px;
     font-weight: lighter;
+}
+
+.carousel-content {
+    background-color: #fff;
+    margin: 20px;
+    padding-left: 40px;
+    padding-right: 30px;
+    text-align: left;
+}
+
+.carousel-control-prev-icon,
+.carousel-control-next-icon,
+.bi-chevron-left,
+.bi-chevron-right {
+    color: #000;
+}
+
+.carousel-heading {
+    text-align: center;
+}
+
+@media (max-width: 768px) {
+    .carousel-content {
+        padding-left: 30px;
+        padding-right: 20px;
+    }
 }


### PR DESCRIPTION
Promised to finish this week. This is a suggestion how we could do a carousel with brief descriptions of recent talks without interfering with the layout of the page too much. 

Not sure if this is the way to fill it with content or it should be extracted out of the main html-file. Also not sure if we're supposed to provide external links and how many - so far just added one but this could be a more heavily editorialized section.

Let me know if you have any comments, questions or suggestions, I'd be happy to improve this solution and make it as convenient and neat as possible.